### PR TITLE
Ubuntu 19.04 EOL, removed.

### DIFF
--- a/os.tf
+++ b/os.tf
@@ -76,10 +76,6 @@ output "freebsd_12_x64" {
   value = local.os_zipped["FreeBSD 12 x64"]
 }
 
-output "ubuntu_1904_x64" {
-  value = local.os_zipped["Ubuntu 19.04 x64"]
-}
-
 output "openbsd_65_x64" {
   value = local.os_zipped["OpenBSD 6.5 x64"]
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->

The removal of Ubuntu 19.04 from the Vultr API OS List results in Terraform init failure when including this module. Fixed by removing EOL Ubuntu 19.04 from module outputs.  

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
