### PR TITLE
Fix OS List.

### DIFF
--- a/os.tf
+++ b/os.tf
@@ -76,10 +76,6 @@ output "freebsd_12_x64" {
   value = local.os_zipped["FreeBSD 12 x64"]
 }
 
-output "openbsd_65_x64" {
-  value = local.os_zipped["OpenBSD 6.5 x64"]
-}
-
 output "fedora_30_x64" {
   value = local.os_zipped["Fedora 30 x64"]
 }
@@ -98,6 +94,10 @@ output "ubuntu_1910_x64" {
 
 output "openbsd_66_x64" {
   value = local.os_zipped["OpenBSD 6.6 x64"]
+}
+
+output "openbsd_67_x64" {
+  value = local.os_zipped["OpenBSD 6.7 x64"]
 }
 
 output "fedora_31_x64" {

--- a/os.tf
+++ b/os.tf
@@ -48,14 +48,6 @@ output "debian_8_i386" {
   value = local.os_zipped["Debian 8 i386 (jessie)"]
 }
 
-output "ubuntu_1604_x64" {
-  value = local.os_zipped["Ubuntu 16.04 x64"]
-}
-
-output "ubuntu_1604_i386" {
-  value = local.os_zipped["Ubuntu 16.04 i386"]
-}
-
 output "freebsd_11_x64" {
   value = local.os_zipped["FreeBSD 11 x64"]
 }
@@ -68,10 +60,6 @@ output "debian_9_x64" {
   value = local.os_zipped["Debian 9 x64 (stretch)"]
 }
 
-output "ubuntu_1804_x64" {
-  value = local.os_zipped["Ubuntu 18.04 x64"]
-}
-
 output "freebsd_12_x64" {
   value = local.os_zipped["FreeBSD 12 x64"]
 }
@@ -82,10 +70,6 @@ output "debian_10_x64" {
 
 output "centos_8_x64" {
   value = local.os_zipped["CentOS 8 x64"]
-}
-
-output "ubuntu_1910_x64" {
-  value = local.os_zipped["Ubuntu 19.10 x64"]
 }
 
 output "openbsd_66_x64" {
@@ -108,3 +92,22 @@ output "fedora_coreos" {
   value = local.os_zipped["Fedora CoreOS"]
 }
 
+output "ubuntu_1604_i386" {
+  value = local.os_zipped["Ubuntu 16.04 i386"]
+}
+
+output "ubuntu_1604_x64" {
+  value = local.os_zipped["Ubuntu 16.04 x64"]
+}
+
+output "ubuntu_1804_x64" {
+  value = local.os_zipped["Ubuntu 18.04 x64"]
+}
+
+output "ubuntu_1910_x64" {
+  value = local.os_zipped["Ubuntu 19.10 x64"]
+}
+
+output "ubuntu_2004_x64" {
+  value = local.os_zipped["Ubuntu 20.04 x64"]
+}

--- a/os.tf
+++ b/os.tf
@@ -76,10 +76,6 @@ output "freebsd_12_x64" {
   value = local.os_zipped["FreeBSD 12 x64"]
 }
 
-output "fedora_30_x64" {
-  value = local.os_zipped["Fedora 30 x64"]
-}
-
 output "debian_10_x64" {
   value = local.os_zipped["Debian 10 x64 (buster)"]
 }
@@ -104,4 +100,11 @@ output "fedora_31_x64" {
   value = local.os_zipped["Fedora 31 x64"]
 }
 
+output "fedora_32_x64" {
+  value = local.os_zipped["Fedora 32 x64"]
+}
+
+output "fedora_coreos" {
+  value = local.os_zipped["Fedora CoreOS"]
+}
 


### PR DESCRIPTION
## Description
This removes the deprecated / EOL operating systems;
* Fedora 31 x64
* OpenBSD 6.5 x64

And adds the following missing operating systems;
* Fedora CoreOS
* OpenBSD 6.7 x64
* Ubuntu 20.04 x64

## Related Issues
The following errors are returned when using the the master branch of `terraform-datalib-vultr` as a library in terraform.

```
Error: Invalid index

  on .terraform/modules/vultr_lib/os.tf line 80, in output "openbsd_65_x64":
  80:   value = local.os_zipped["OpenBSD 6.5 x64"]
    |----------------
    | local.os_zipped is object with 27 attributes

The given key does not identify an element in this collection value.


Error: Invalid index

  on .terraform/modules/vultr_lib/os.tf line 84, in output "fedora_30_x64":
  84:   value = local.os_zipped["Fedora 30 x64"]
    |----------------
    | local.os_zipped is object with 27 attributes

The given key does not identify an element in this collection value.
```

### Checklist:

* [:heavy_check_mark:] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [:heavy_check_mark:] Have you successfully ran tests with your changes locally?
