### PR TITLE
Add Instance Plans as aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # terraform-datalib-vultr
-Data only module for Vultr. Maps Application, OS, and Region human readable names to ID's. 
+Data only module for Vultr. Maps Application, Plans, OS, and Region human readable names to ID's.
 
-This module will remove the need to curl the public api endpoints to find App/OS/Region ID’s. The Terraform HTTP datasources  pulls all Apps/OS’s/Regions in 3 calls then maps them to human readable names to the respective ID in separate outputs. The output names have been made to be relatively human readable, and will return the ID of the App, OS, or Region you are naming.
-
-### TODO
-* Plans - need to determine a descriptive but reasonably short naming scheme. 
+This module will remove the need to curl the public api endpoints to find App/Plans/OS/Region ID’s. The Terraform HTTP datasources pulls all Apps/OS’s/Regions in four calls then maps them to human readable names to the respective ID in separate outputs. The output names have been made to be relatively human readable, and will return the ID of the App, OS, or Region you are naming.
 
 ## Usage
 Import the module like you would any other TF Module:
@@ -14,11 +11,12 @@ module "vultr_lib" {
 }
 ```
 
-Use human readable module output names in place of Application, OS, or Region ID's:
+Use human readable module output names in place of Plans, Application, OS, or Region ID's:
 
 ```hcl
 resource "vultr_server" "server0" {
-  plan_id = "201"
+  plan_id = module.vultr_lib.vc1_m1_s1x25 // 1x VCPU, 1GB RAM, 1x25GB SSD
+  plan_id = module.vultr_lib.vc2_m4_s1x80 // 2x VCPUs, 4GB RAM, 1x80GB SSD
   region_id = module.vultr_lib.new_jersey
   # region_id = module.vultr_lib.atlanta
   # region_id = module.vultr_lib.dallas

--- a/baremetal.tf
+++ b/baremetal.tf
@@ -1,4 +1,4 @@
-output "vbm-4cpu-32gb" {
+output "vbm_4cpu_32gb" {
     description = "Vultr Bare Metal (VBM): 4x CPU, 32768 MB RAM,2x 240 GB SSD,5.00 TB BW"
     value = 100
 }

--- a/baremetal.tf
+++ b/baremetal.tf
@@ -1,0 +1,4 @@
+output "vbm-4cpu-32gb" {
+    description = "Vultr Bare Metal (VBM): 4x CPU, 32768 MB RAM,2x 240 GB SSD,5.00 TB BW"
+    value = 100
+}

--- a/plans.tf
+++ b/plans.tf
@@ -1,94 +1,94 @@
-output "vc2-1vcpu-1gb" {
+output "vc2_1vcpu_1gb" {
     description = "Vultr Cloud Compute (VC2): 1024 MB RAM,25 GB SSD,1.00 TB BW"
     value = 201
 }
 
-output "vc2-1vcpu-2gb" {
+output "vc2_1vcpu_2gb" {
     description = "Vultr Cloud Compute (VC2): 2048 MB RAM,55 GB SSD,2.00 TB BW"
     value = 202
 }
 
-output "vc2-2vcpu-4gb" {
+output "vc2_2vcpu_4gb" {
     description = "Vultr Cloud Compute (VC2): 4096 MB RAM,80 GB SSD,3.00 TB BW"
     value = 203
 }
 
-output "vc2-4vcpu-8gb" {
+output "vc2_4vcpu_8gb" {
     description = "Vultr Cloud Compute (VC2): 8192 MB RAM,160 GB SSD,4.00 TB BW"
     value = 204
 }
 
-output "vc2-6vcpu-16gb" {
+output "vc2_6vcpu_16gb" {
     description = "Vultr Cloud Compute (VC2): 16384 MB RAM,320 GB SSD,5.00 TB BW"
     value = 205
 }
 
-output "vc2-8vcpu-32gb" {
+output "vc2_8vcpu_32gb" {
     description = "Vultr Cloud Compute (VC2): 32768 MB RAM,640 GB SSD,6.00 TB BW"
     value = 206
 }
 
-output "vc2-16vcpu-64gb" {
+output "vc2_16vcpu_64gb" {
     description = "Vultr Cloud Compute (VC2): 65536 MB RAM,1280 GB SSD,10.00 TB BW"
     value = 207
 }
 
-output "vc2-24vcpu-96gb" {
+output "vc2_24vcpu_96gb" {
     description = "Vultr Cloud Compute (VC2): 98304 MB RAM,1600 GB SSD,15.00 TB BW"
     value = 208
 }
 
-output "vdc-2vcpu-8gb" {
+output "vdc_2vcpu_8gb" {
     description = "Vultr Dedicated Cloud (VDC): 8192 MB RAM,110 GB SSD,10.00 TB BW"
     value = 115
 }
 
-output "vdc-4vcpu-16gb" {
+output "vdc_4vcpu_16gb" {
     description = "Vultr Dedicated Cloud (VDC): 16384 MB RAM,2x110 GB SSD,20.00 TB BW"
     value = 116
 }
 
-output "vdc-6vcpu-24gb" {
+output "vdc_6vcpu_24gb" {
     description = "Vultr Dedicated Cloud (VDC): 24576 MB RAM,3x110 GB SSD,30.00 TB BW"
     value = 117
 }
 
-output "vdc-8vcpu-32gb" {
+output "vdc_8vcpu_32gb" {
     description = "Vultr Dedicated Cloud (VDC): 32768 MB RAM,4x110 GB SSD,40.00 TB BW"
     value = 118
 }
 
-output "vhf-1vcpu-1gb" {
+output "vhf_1vcpu_1gb" {
     description = "Vultr High Frequency (VHF): 1024 MB RAM,32 GB SSD,1.00 TB BW"
     value = 400
 }
 
-output "vhf-1vcpu-2gb" {
+output "vhf_1vcpu_2gb" {
     description = "Vultr High Frequency (VHF): 2048 MB RAM,64 GB SSD,2.00 TB BW"
     value = 401
 }
 
-output "vhf-2vcpu-4gb" {
+output "vhf_2vcpu_4gb" {
     description = "Vultr High Frequency (VHF): 4096 MB RAM,128 GB SSD,3.00 TB BW"
     value = 402
 }
 
-output "vhf-3vcpu-8gb" {
+output "vhf_3vcpu_8gb" {
     description = "Vultr High Frequency (VHF): 8192 MB RAM,256 GB SSD,4.00 TB BW"
     value = 403
 }
 
-output "vhf-4vcpu-16gb" {
+output "vhf_4vcpu_16gb" {
     description = "Vultr High Frequency (VHF): 16384 MB RAM,384 GB SSD,5.00 TB BW"
     value = 404
 }
 
-output "vhf-8vcpu-32gb" {
+output "vhf_8vcpu_32gb" {
     description = "Vultr High Frequency (VHF): 32768 MB RAM,512 GB SSD,6.00 TB BW"
     value = 405
 }
 
-output "vhf-12vcpu-48gb" {
+output "vhf_12vcpu_48gb" {
     description = "Vultr High Frequency (VHF): 49152 MB RAM,768 GB SSD,8.00 TB BW"
     value = 406
 }

--- a/plans.tf
+++ b/plans.tf
@@ -7,92 +7,97 @@ locals {
   : join("", [plan.vcpu_count, " VCPU,", plan.name]) => plan.VPSPLANID}
 }
 
-// Plan ID: 201
-output "vc1_m1_s1x25" {
-  value = local.plans["1 VCPU,1024 MB RAM,25 GB SSD,1.00 TB BW"]
+output "vc2-1vcpu-1gb" {
+    description = "Vultr Cloud Compute (VC2): 1024 MB RAM,25 GB SSD,1.00 TB BW"
+    value = 201
 }
 
-// Plan ID: 400
-output "vc1_m1_s1x32" {
-  value = local.plans["1 VCPU,1024 MB RAM,32 GB SSD,1.00 TB BW"]
+output "vc2-1vcpu-2gb" {
+    description = "Vultr Cloud Compute (VC2): 2048 MB RAM,55 GB SSD,2.00 TB BW"
+    value = 202
 }
 
-// Plan ID: 202
-output "vc1_m2_s1x55" {
-  value = local.plans["1 VCPU,2048 MB RAM,55 GB SSD,2.00 TB BW"]
+output "vc2-2vcpu-4gb" {
+    description = "Vultr Cloud Compute (VC2): 4096 MB RAM,80 GB SSD,3.00 TB BW"
+    value = 203
 }
 
-// Plan ID: 401
-output "vc1_m2_s1x64" {
-  value = local.plans["1 VCPU,2048 MB RAM,64 GB SSD,2.00 TB BW"]
+output "vc2-4vcpu-8gb" {
+    description = "Vultr Cloud Compute (VC2): 8192 MB RAM,160 GB SSD,4.00 TB BW"
+    value = 204
 }
 
-// Plan ID: 203
-output "vc2_m4_s1x80" {
-  value = local.plans["2 VCPU,4096 MB RAM,80 GB SSD,3.00 TB BW"]
+output "vc2-6vcpu-16gb" {
+    description = "Vultr Cloud Compute (VC2): 16384 MB RAM,320 GB SSD,5.00 TB BW"
+    value = 205
 }
 
-// Plan ID: 204
-output "vc4_m18s1x160" {
-  value = local.plans["4 VCPU,8192 MB RAM,160 GB SSD,4.00 TB BW"]
+output "vc2-8vcpu-32gb" {
+    description = "Vultr Cloud Compute (VC2): 32768 MB RAM,640 GB SSD,6.00 TB BW"
+    value = 206
 }
 
-// Plan ID: 403
-output "vc3_m8_s1x256" {
-  value = local.plans["3 VCPU,8192 MB RAM,256 GB SSD,4.00 TB BW"]
+output "vc2-16vcpu-64gb" {
+    description = "Vultr Cloud Compute (VC2): 65536 MB RAM,1280 GB SSD,10.00 TB BW"
+    value = 207
 }
 
-// Plan ID: 115
-output "vc2_m8_s1x110" {
-  value = local.plans["2 VCPU,8192 MB RAM,110 GB SSD,10.00 TB BW"]
+output "vc2-24vcpu-96gb" {
+    description = "Vultr Cloud Compute (VC2): 98304 MB RAM,1600 GB SSD,15.00 TB BW"
+    value = 208
 }
 
-// Plan ID: 205
-output "vc1_m16_s1x320" {
-  value = local.plans["6 VCPU,16384 MB RAM,320 GB SSD,5.00 TB BW"]
+output "vdc-2vcpu-8gb" {
+    description = "Vultr Dedicated Cloud (VDC): 8192 MB RAM,110 GB SSD,10.00 TB BW"
+    value = 115
 }
 
-// Plan ID: 404
-output "vc4_m16_s1x384" {
-  value = local.plans["4 VCPU,16384 MB RAM,384 GB SSD,5.00 TB BW"]
+output "vdc-4vcpu-16gb" {
+    description = "Vultr Dedicated Cloud (VDC): 16384 MB RAM,2x110 GB SSD,20.00 TB BW"
+    value = 116
 }
 
-// Plan ID: 116
-output "vc4_m16_s2x110" {
-  value = local.plans["4 VCPU,16384 MB RAM,2x110 GB SSD,20.00 TB BW"]
+output "vdc-6vcpu-24gb" {
+    description = "Vultr Dedicated Cloud (VDC): 24576 MB RAM,3x110 GB SSD,30.00 TB BW"
+    value = 117
 }
 
-// Plan ID: 206
-output "vc8_m32_s1x640" {
-  value = local.plans["8 VCPU,32768 MB RAM,640 GB SSD,6.00 TB BW"]
+output "vdc-8vcpu-32gb" {
+    description = "Vultr Dedicated Cloud (VDC): 32768 MB RAM,4x110 GB SSD,40.00 TB BW"
+    value = 118
 }
 
-// Plan ID: 117
-output "vc6_m24_s3x110" {
-  value = local.plans["6 VCPU,24576 MB RAM,3x110 GB SSD,30.00 TB BW"]
+output "vhf-1vcpu-1gb" {
+    description = "Vultr High Frequency (VHF): 1024 MB RAM,32 GB SSD,1.00 TB BW"
+    value = 400
 }
 
-// Plan ID: 405
-output "vc8_m32_s1x512" {
-  value = local.plans["8 VCPU,32768 MB RAM,512 GB SSD,6.00 TB BW"]
+output "vhf-1vcpu-2gb" {
+    description = "Vultr High Frequency (VHF): 2048 MB RAM,64 GB SSD,2.00 TB BW"
+    value = 401
 }
 
-// Plan ID: 118
-output "vc8_m32_s4x110" {
-  value = local.plans["8 VCPU,32768 MB RAM,4x110 GB SSD,40.00 TB BW"]
+output "vhf-2vcpu-4gb" {
+    description = "Vultr High Frequency (VHF): 4096 MB RAM,128 GB SSD,3.00 TB BW"
+    value = 402
 }
 
-// Plan ID: 406
-output "vc12_m48_s1x768" {
-  value = local.plans["12 VCPU,49152 MB RAM,768 GB SSD,8.00 TB BW"]
+output "vhf-3vcpu-8gb" {
+    description = "Vultr High Frequency (VHF): 8192 MB RAM,256 GB SSD,4.00 TB BW"
+    value = 403
 }
 
-// Plan ID: 207
-output "vc16_m64_s1x1280" {
-  value = local.plans["16 VCPU,65536 MB RAM,1280 GB SSD,10.00 TB BW"]
+output "vhf-4vcpu-16gb" {
+    description = "Vultr High Frequency (VHF): 16384 MB RAM,384 GB SSD,5.00 TB BW"
+    value = 404
 }
 
-// Plan ID: 208
-output "vc24_m96_s1x1600" {
-  value = local.plans["24 VCPU,98304 MB RAM,1600 GB SSD,15.00 TB BW"]
+output "vhf-8vcpu-32gb" {
+    description = "Vultr High Frequency (VHF): 32768 MB RAM,512 GB SSD,6.00 TB BW"
+    value = 405
+}
+
+output "vhf-12vcpu-48gb" {
+    description = "Vultr High Frequency (VHF): 49152 MB RAM,768 GB SSD,8.00 TB BW"
+    value = 406
 }

--- a/plans.tf
+++ b/plans.tf
@@ -3,20 +3,96 @@ data "http" "vultr_vserver_plans" {
 }
 
 locals {
-  plan_name		= values(jsondecode(data.http.vultr_vserver_plans.body))[*].name
-  plan_ids		= values(jsondecode(data.http.vultr_vserver_plans.body))[*].VPSPLANID
-  plan_zipped   = zipmap(local.plan_name, local.plan_ids)
+  plans = {for plan in values(jsondecode(data.http.vultr_vserver_plans.body))
+  : join("", [plan.vcpu_count, " VCPU,", plan.name]) => plan.VPSPLANID}
 }
 
-// CPU: 1 x Virtual CPU, RAM: 1gb, Storage: 1 x 25 GB
-output "c1_m1_s1x25" {
-  value = local.plan_zipped["1024 MB RAM,25 GB SSD,1.00 TB BW"]
+// Plan ID: 201
+output "vc1_m1_s1x25" {
+  value = local.plans["1 VCPU,1024 MB RAM,25 GB SSD,1.00 TB BW"]
 }
 
-output "c1_m1_s1x32" {
-  value = local.plan_zipped["1024 MB RAM,32 GB SSD,1.00 TB BW"]
+// Plan ID: 400
+output "vc1_m1_s1x32" {
+  value = local.plans["1 VCPU,1024 MB RAM,32 GB SSD,1.00 TB BW"]
 }
 
-output "c2_m4_s1x80" {
-  value = local.plan_zipped["4096 MB RAM,80 GB SSD,3.00 TB BW"]
+// Plan ID: 202
+output "vc1_m2_s1x55" {
+  value = local.plans["1 VCPU,2048 MB RAM,55 GB SSD,2.00 TB BW"]
+}
+
+// Plan ID: 401
+output "vc1_m2_s1x64" {
+  value = local.plans["1 VCPU,2048 MB RAM,64 GB SSD,2.00 TB BW"]
+}
+
+// Plan ID: 203
+output "vc2_m4_s1x80" {
+  value = local.plans["2 VCPU,4096 MB RAM,80 GB SSD,3.00 TB BW"]
+}
+
+// Plan ID: 204
+output "vc4_m18s1x160" {
+  value = local.plans["4 VCPU,8192 MB RAM,160 GB SSD,4.00 TB BW"]
+}
+
+// Plan ID: 403
+output "vc3_m8_s1x256" {
+  value = local.plans["3 VCPU,8192 MB RAM,256 GB SSD,4.00 TB BW"]
+}
+
+// Plan ID: 115
+output "vc2_m8_s1x110" {
+  value = local.plans["2 VCPU,8192 MB RAM,110 GB SSD,10.00 TB BW"]
+}
+
+// Plan ID: 205
+output "vc1_m16_s1x320" {
+  value = local.plans["6 VCPU,16384 MB RAM,320 GB SSD,5.00 TB BW"]
+}
+
+// Plan ID: 404
+output "vc4_m16_s1x384" {
+  value = local.plans["4 VCPU,16384 MB RAM,384 GB SSD,5.00 TB BW"]
+}
+
+// Plan ID: 116
+output "vc4_m16_s2x110" {
+  value = local.plans["4 VCPU,16384 MB RAM,2x110 GB SSD,20.00 TB BW"]
+}
+
+// Plan ID: 206
+output "vc8_m32_s1x640" {
+  value = local.plans["8 VCPU,32768 MB RAM,640 GB SSD,6.00 TB BW"]
+}
+
+// Plan ID: 117
+output "vc6_m24_s3x110" {
+  value = local.plans["6 VCPU,24576 MB RAM,3x110 GB SSD,30.00 TB BW"]
+}
+
+// Plan ID: 405
+output "vc8_m32_s1x512" {
+  value = local.plans["8 VCPU,32768 MB RAM,512 GB SSD,6.00 TB BW"]
+}
+
+// Plan ID: 118
+output "vc8_m32_s4x110" {
+  value = local.plans["8 VCPU,32768 MB RAM,4x110 GB SSD,40.00 TB BW"]
+}
+
+// Plan ID: 406
+output "vc12_m48_s1x768" {
+  value = local.plans["12 VCPU,49152 MB RAM,768 GB SSD,8.00 TB BW"]
+}
+
+// Plan ID: 207
+output "vc16_m64_s1x1280" {
+  value = local.plans["16 VCPU,65536 MB RAM,1280 GB SSD,10.00 TB BW"]
+}
+
+// Plan ID: 208
+output "vc24_m96_s1x1600" {
+  value = local.plans["24 VCPU,98304 MB RAM,1600 GB SSD,15.00 TB BW"]
 }

--- a/plans.tf
+++ b/plans.tf
@@ -1,0 +1,22 @@
+data "http" "vultr_vserver_plans" {
+  url = "https://api.vultr.com/v1/plans/list"
+}
+
+locals {
+  plan_name		= values(jsondecode(data.http.vultr_vserver_plans.body))[*].name
+  plan_ids		= values(jsondecode(data.http.vultr_vserver_plans.body))[*].VPSPLANID
+  plan_zipped   = zipmap(local.plan_name, local.plan_ids)
+}
+
+// CPU: 1 x Virtual CPU, RAM: 1gb, Storage: 1 x 25 GB
+output "c1_m1_s1x25" {
+  value = local.plan_zipped["1024 MB RAM,25 GB SSD,1.00 TB BW"]
+}
+
+output "c1_m1_s1x32" {
+  value = local.plan_zipped["1024 MB RAM,32 GB SSD,1.00 TB BW"]
+}
+
+output "c2_m4_s1x80" {
+  value = local.plan_zipped["4096 MB RAM,80 GB SSD,3.00 TB BW"]
+}

--- a/plans.tf
+++ b/plans.tf
@@ -1,12 +1,3 @@
-data "http" "vultr_vserver_plans" {
-  url = "https://api.vultr.com/v1/plans/list"
-}
-
-locals {
-  plans = {for plan in values(jsondecode(data.http.vultr_vserver_plans.body))
-  : join("", [plan.vcpu_count, " VCPU,", plan.name]) => plan.VPSPLANID}
-}
-
 output "vc2-1vcpu-1gb" {
     description = "Vultr Cloud Compute (VC2): 1024 MB RAM,25 GB SSD,1.00 TB BW"
     value = 201

--- a/scripts/plans.py
+++ b/scripts/plans.py
@@ -37,5 +37,5 @@ for id in plans:
     desc_text = f'{desc_type}: {description}'
     cpus = plans[id]['vcpu_count']
     ram = int(int(plans[id]['ram']) / 1024)
-    terraid = f'{prefix}-{cpus}vcpu-{ram}gb'
+    terraid = f'{prefix}_{cpus}vcpu_{ram}gb'
     print(template.substitute(name=terraid, desc=desc_text, id=id))

--- a/scripts/plans.py
+++ b/scripts/plans.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+import json
+import requests
+from string import Template
+
+uri = "https://api.vultr.com/v1/plans/list"
+
+plans = json.loads(requests.get(uri).content)
+
+types_map = {'SSD': 'vc2', 'HIGHFREQUENCY': 'vhf', 'DEDICATED': 'vdc'}
+description_map = {
+    'SSD': 'Vultr Cloud Compute (VC2)',
+    'HIGHFREQUENCY': 'Vultr High Frequency (VHF)',
+    'DEDICATED': 'Vultr Dedicated Cloud (VDC)'
+}
+template = Template('output "$name" {\n    description = "$desc"\n    value = $id\n}\n')
+
+for id in plans:
+    type = plans[id]['plan_type']
+    description = plans[id]['name']
+    prefix = types_map[type]
+    desc_type = description_map[type]
+    desc_text = f'{desc_type}: {description}'
+    cpus = plans[id]['vcpu_count']
+    ram = int(int(plans[id]['ram']) / 1024)
+    terraid = f'{prefix}-{cpus}vcpu-{ram}gb'
+    print(template.substitute(name=terraid, desc=desc_text, id=id))

--- a/scripts/plans.py
+++ b/scripts/plans.py
@@ -1,4 +1,18 @@
 #!/usr/bin/python3
+"""Vultr Terraform plans generator
+
+This script generates a list of plans of all the Vultr VM for use with terraform.
+
+The script does not accept any arguments, and will simply output the result to stdout.
+
+Each entry should conform to the following example format;
+
+output "vdc-4vcpu-16gb" {
+    description = "Vultr Dedicated Cloud (VDC): 16384 MB RAM,2x110 GB SSD,20.00 TB BW"
+    value = 116
+}
+"""
+
 import json
 import requests
 from string import Template


### PR DESCRIPTION
This adds the ability select plans by a shortname, rather than a integer ID.

## Description
The VC2 plan is identified by VCPU, RAM, and Storage.

For example:
```hcl
resource "vultr_server" "server0" {
  plan_id = module.vultr_lib.vc1_m1_s1x25
}
```

### Checklist:

* :heavy_check_mark: Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* :heavy_check_mark: Have you linted your code locally prior to submission?
* :heavy_check_mark: Have you successfully ran tests with your changes locally?
